### PR TITLE
Loosen version constraints for Rails 4.2 and 5.0 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,14 @@ ruby-2-6: &ruby-2-6
   docker:
     - image: circleci/ruby:2.6
 
+rails-4-2: &rails-4-2
+  environment:
+      RAILS_VERSION: "~> 4.2.0"
+
+rails-5-0: &rails-5-0
+  environment:
+      RAILS_VERSION: "~> 5.0.0"
+
 rails-5-1: &rails-5-1
   environment:
       RAILS_VERSION: "~> 5.1.0"
@@ -44,6 +52,14 @@ rails-edge: &rails-edge
       RAILS_BRANCH: "master"
 
 jobs:
+  "ruby-2-4-rails-4-2":
+    <<: *ruby-2-4
+    <<: *rails-4-2
+    <<: *build_steps
+  "ruby-2-4-rails-5-0":
+    <<: *ruby-2-4
+    <<: *rails-5-0
+    <<: *build_steps
   "ruby-2-4-rails-5-1":
     <<: *ruby-2-4
     <<: *rails-5-1
@@ -53,6 +69,10 @@ jobs:
     <<: *rails-5-2
     <<: *build_steps
 
+  "ruby-2-5-rails-5-0":
+    <<: *ruby-2-5
+    <<: *rails-5-0
+    <<: *build_steps
   "ruby-2-5-rails-5-1":
     <<: *ruby-2-5
     <<: *rails-5-1
@@ -70,6 +90,10 @@ jobs:
     <<: *rails-edge
     <<: *build_steps
 
+  "ruby-2-6-rails-5-0":
+    <<: *ruby-2-6
+    <<: *rails-5-0
+    <<: *build_steps
   "ruby-2-6-rails-5-1":
     <<: *ruby-2-6
     <<: *rails-5-1
@@ -91,14 +115,17 @@ workflows:
   version: 2
   build:
     jobs:
+      - "ruby-2-4-rails-4-2"
       - "ruby-2-4-rails-5-1"
       - "ruby-2-4-rails-5-2"
 
+      - "ruby-2-5-rails-5-0"
       - "ruby-2-5-rails-5-1"
       - "ruby-2-5-rails-5-2"
       - "ruby-2-5-rails-6-0"
       - "ruby-2-5-rails-edge"
 
+      - "ruby-2-6-rails-5-0"
       - "ruby-2-6-rails-5-1"
       - "ruby-2-6-rails-5-2"
       - "ruby-2-6-rails-6-0"

--- a/omniauth-rails_csrf_protection.gemspec
+++ b/omniauth-rails_csrf_protection.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "actionpack", ">= 5.1.0"
+  spec.add_dependency "actionpack", ">= 4.2"
   spec.add_dependency "omniauth", ">= 1.3.1"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
Add these Rails versions to CI test matrix, where everything passes.

The Rails 4.2 and 5.0 series are still supported for critical vulnerabilities (https://rubyonrails.org/security/), so it would be great to be able to use this gem for those. Thanks for providing this gem!