### PR TITLE
Avoid modifying POST params on env while checking for CSRF token

### DIFF
--- a/lib/omniauth/rails_csrf_protection/token_verifier.rb
+++ b/lib/omniauth/rails_csrf_protection/token_verifier.rb
@@ -28,7 +28,7 @@ module OmniAuth
       end
 
       def call(env)
-        @request = ActionDispatch::Request.new(env)
+        @request = ActionDispatch::Request.new(env.dup)
 
         unless verified_request?
           raise ActionController::InvalidAuthenticityToken


### PR DESCRIPTION
When `env` is used to create a request, trying to access the POST parameters causes `ActionDispatch::Request` to [parse them into a hash and reassign them back to `env`](https://github.com/rails/rails/blob/b9ca94caea2ca6a6cc09abaffaad67b447134079/actionpack/lib/action_dispatch/http/request.rb#L381-L384). While [parsing is minimal](https://github.com/rails/rails/blob/b9ca94caea2ca6a6cc09abaffaad67b447134079/actionpack/lib/action_dispatch/http/parameters.rb#L10-L15), there is a possibility that it will try to [parse and convert times, using the set time zone](https://github.com/rails/rails/blob/b9ca94caea2ca6a6cc09abaffaad67b447134079/activesupport/lib/active_support/json/decoding.rb#L22-L30), which can interfere with later processing of the parameters. A simple way to avoid this is to call `env.dup` when creating the request.