### PR TITLE
Support for omniauth v2.0.0

### DIFF
--- a/lib/omniauth/rails_csrf_protection/railtie.rb
+++ b/lib/omniauth/rails_csrf_protection/railtie.rb
@@ -4,8 +4,7 @@ module OmniAuth
   module RailsCsrfProtection
     class Railtie < Rails::Railtie
       initializer "omniauth-rails_csrf_protection.initialize" do
-        OmniAuth.config.allowed_request_methods = [:post]
-        OmniAuth.config.before_request_phase = TokenVerifier.new
+        OmniAuth.config.request_validation_phase = TokenVerifier.new
       end
     end
   end

--- a/lib/omniauth/rails_csrf_protection/version.rb
+++ b/lib/omniauth/rails_csrf_protection/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module RailsCsrfProtection
-    VERSION = "0.1.2".freeze
+    VERSION = "1.0.0".freeze
   end
 end

--- a/omniauth-rails_csrf_protection.gemspec
+++ b/omniauth-rails_csrf_protection.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "actionpack", ">= 4.2"
-  spec.add_dependency "omniauth", ">= 1.3.1"
+  spec.add_dependency "omniauth", "~> 2.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest"

--- a/test/application_test.rb
+++ b/test/application_test.rb
@@ -11,14 +11,16 @@ class ApplicationTest < Minitest::Test
 
   def test_request_phrase_without_token_via_post
     post "/auth/developer"
+    follow_redirect!
 
-    assert last_response.unprocessable?
+    assert last_response.not_found?
   end
 
   def test_request_phrase_with_bad_token_via_post
     post "/auth/developer", authenticity_token: "BAD_TOKEN"
+    follow_redirect!
 
-    assert last_response.unprocessable?
+    assert last_response.not_found?
   end
 
   def test_request_phrase_with_correct_token_via_post


### PR DESCRIPTION
OmniAuth v2.0.0 has been released, this change allows folks to use v2.0.0 without manually setting a request_validation_phase that is required for rails apps using OmniAuth v2.0.0 

[2.0.0 release notes](https://github.com/omniauth/omniauth/releases/tag/v2.0.0)