### PR TITLE
Fixes #12 Add missing ominauth require

### DIFF
--- a/lib/omniauth/rails_csrf_protection/railtie.rb
+++ b/lib/omniauth/rails_csrf_protection/railtie.rb
@@ -1,3 +1,4 @@
+require "omniauth"
 require "omniauth/rails_csrf_protection/token_verifier"
 
 module OmniAuth


### PR DESCRIPTION
Fixes https://github.com/cookpad/omniauth-rails_csrf_protection/issues/12

The mentioned issue happens when `omniauth` is not added explicitly to Gemfile, hence bundler does not require it.

But since `omniauth-rails_csrf_protection` assumes the `ominauth` is already required, it errors out when user only adds `omniauth-rails_csrf_protection` but does not add `omniauth` to `Gemfile`.

This PR adds missing `require` for `omniauth` gem.

Bug script:
```ruby
require 'bundler/inline'

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", '7.0.0.alpha2'
  gem 'omniauth-rails_csrf_protection'
end

class TestApp < Rails::Application
  config.root = __dir__
  config.eager_load = false
end

ENV["DATABASE_URL"] = "sqlite3::memory:"

Rails.application.initialize!
```
<details>
<summary>Log</summary>

```
❱ ruby test.rb
Fetching gem metadata from https://rubygems.org/.............
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies....
Using rake 13.0.6
Using concurrent-ruby 1.1.9
Using minitest 5.14.4
Using builder 3.2.4
Using erubi 1.10.0
Using racc 1.6.0
Using crass 1.0.6
Using rack 2.2.3
Using nio4r 2.5.8
Using zeitwerk 2.5.0
Using i18n 1.8.10
Using mini_mime 1.1.2
Using tzinfo 2.0.4
Using rack-test 1.1.0
Using method_source 1.0.0
Using thor 1.1.0
Using sprockets 4.0.2
Using activesupport 7.0.0.alpha2
Using nokogiri 1.12.5 (x86_64-linux)
Using globalid 0.5.2
Using rails-dom-testing 2.0.3
Using hashie 4.1.0
Using activejob 7.0.0.alpha2
Using mail 2.7.1
Using marcel 1.0.2
Using activemodel 7.0.0.alpha2
Using bundler 2.2.3
Using rack-protection 2.1.0
Using websocket-extensions 0.1.5
Using loofah 2.12.0
Using activerecord 7.0.0.alpha2
Using omniauth 2.0.4
Using websocket-driver 0.7.5
Using rails-html-sanitizer 1.4.2
Using actionview 7.0.0.alpha2
Using actionpack 7.0.0.alpha2
Using actioncable 7.0.0.alpha2
Using railties 7.0.0.alpha2
Using actionmailer 7.0.0.alpha2
Using omniauth-rails_csrf_protection 1.0.0
Using sprockets-rails 3.2.2
Using activestorage 7.0.0.alpha2
Using actionmailbox 7.0.0.alpha2
Using actiontext 7.0.0.alpha2


Using rails 7.0.0.alpha2
/home/akshay/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/omniauth-rails_csrf_protection-1.0.0/lib/omniauth/rails_csrf_protection/railtie.rb:7:in `block in <class:Railtie>': undefined method `config' for OmniAuth:Module (NoMethodError)
Did you mean?  concerning
        from /home/akshay/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/railties-7.0.0.alpha2/lib/rails/initializable.rb:32:in `instance_exec'
        from /home/akshay/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/railties-7.0.0.alpha2/lib/rails/initializable.rb:32:in `run'
        from /home/akshay/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/railties-7.0.0.alpha2/lib/rails/initializable.rb:61:in `block in run_initializers'
        from /home/akshay/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:228:in `block in tsort_each'
        from /home/akshay/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
        from /home/akshay/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:431:in `each_strongly_connected_component_from'
        from /home/akshay/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:349:in `block in each_strongly_connected_component'
        from /home/akshay/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:347:in `each'
        from /home/akshay/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:347:in `call'
        from /home/akshay/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:347:in `each_strongly_connected_component'
        from /home/akshay/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:226:in `tsort_each'
        from /home/akshay/.rbenv/versions/3.0.0/lib/ruby/3.0.0/tsort.rb:205:in `tsort_each'
        from /home/akshay/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/railties-7.0.0.alpha2/lib/rails/initializable.rb:60:in `run_initializers'
        from /home/akshay/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/railties-7.0.0.alpha2/lib/rails/application.rb:369:in `initialize!'
        from test.rb:19:in `<main>'
```
</details>

Update bug script with this PR:
```ruby
require 'bundler/inline'

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", '7.0.0.alpha2'
  gem 'omniauth-rails_csrf_protection', git: 'https://github.com/the-spectator/omniauth-rails_csrf_protection', branch: 'fix_missing'
end

class TestApp < Rails::Application
  config.root = __dir__
  config.eager_load = false
end

ENV["DATABASE_URL"] = "sqlite3::memory:"

Rails.application.initialize!
```

<details>
<summary>Log</summary>
```
require 'bundler/inline'

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", '7.0.0.alpha2'
  gem 'omniauth-rails_csrf_protection', git: 'https://github.com/the-spectator/omniauth-rails_csrf_protection', branch: 'fix_missing'
end

class TestApp < Rails::Application
  config.root = __dir__
  config.eager_load = false
end

ENV["DATABASE_URL"] = "sqlite3::memory:"

Rails.application.initialize!
```
</details>