### PR TITLE
Remove usage of git in gemspec

### DIFF
--- a/omniauth-rails_csrf_protection.gemspec
+++ b/omniauth-rails_csrf_protection.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.homepage    = "https://github.com/cookpad/omniauth-rails_csrf_protection"
   spec.license     = "MIT"
 
-  spec.files       = Dir['lib/**/*.rb']
+  spec.files       = Dir['lib/**/*.rb', 'LICENSE.txt', 'README.md']
   spec.test_files  = Dir['test/**/*.rb']
 
   spec.require_paths = ["lib"]

--- a/omniauth-rails_csrf_protection.gemspec
+++ b/omniauth-rails_csrf_protection.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.homepage    = "https://github.com/cookpad/omniauth-rails_csrf_protection"
   spec.license     = "MIT"
 
-  spec.files       = Dir['lib/**/*.rb', 'LICENSE.txt', 'README.md']
-  spec.test_files  = Dir['test/**/*.rb']
+  spec.files       = Dir["lib/**/*.rb", "LICENSE.txt", "README.md"]
+  spec.test_files  = Dir["test/**/*.rb"]
 
   spec.require_paths = ["lib"]
 

--- a/omniauth-rails_csrf_protection.gemspec
+++ b/omniauth-rails_csrf_protection.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.homepage    = "https://github.com/cookpad/omniauth-rails_csrf_protection"
   spec.license     = "MIT"
 
-  spec.files       = `git ls-files`.split("\n")
-  spec.test_files  = `git ls-files -- test/*`.split("\n")
+  spec.files       = Dir['lib/**/*.rb']
+  spec.test_files  = Dir['test/**/*.rb']
 
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
I am in the process of packaging this gem for Debian and in Debian, we try to avoid using git in the gemspec because if we do we would have to add git as a build dependency for the package ([more info](https://packaging.rubystyle.guide/#using-git-in-gemspec)). Let me know your thoughts regarding this. Thanks!