### PR TITLE
Make TokenVerifier#call safely reentrant

### DIFF
--- a/lib/omniauth/rails_csrf_protection/token_verifier.rb
+++ b/lib/omniauth/rails_csrf_protection/token_verifier.rb
@@ -28,6 +28,10 @@ module OmniAuth
       end
 
       def call(env)
+        dup._call(env)
+      end
+
+      def _call(env)
         @request = ActionDispatch::Request.new(env.dup)
 
         unless verified_request?


### PR DESCRIPTION
In a multi-threaded app, two threads might update `@request` before either thread is able to evaluate `verified_request?`.

In order to retain backward-compatibility, this is fixed by using `dup` and then calling the original implementation on that copy.

_Fixes #16._