### PR TITLE
Add rails 7.2 and 8.0 to the build matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
           - ruby: "3.1"
             rails: ~> 7.1.0
           - ruby: "3.1"
-            rails: edge
+            rails: ~> 7.2.0
 
           - ruby: "3.2"
             rails: ~> 6.0.0
@@ -84,6 +84,10 @@ jobs:
           - ruby: "3.2"
             rails: ~> 7.1.0
           - ruby: "3.2"
+            rails: ~> 7.2.0
+          - ruby: "3.2"
+            rails: ~> 8.0.0
+          - ruby: "3.2"
             rails: edge
 
           - ruby: "3.3"
@@ -94,6 +98,10 @@ jobs:
             rails: ~> 7.0.0
           - ruby: "3.3"
             rails: ~> 7.1.0
+          - ruby: "3.3"
+            rails: ~> 7.2.0
+          - ruby: "3.3"
+            rails: ~> 8.0.0
           - ruby: "3.3"
             rails: edge
 


### PR DESCRIPTION
Also, edge rails requires ruby 3.2 now, so it's dropped from ruby 3.1.