### PR TITLE
fix: remove deprecated ActiveSupport::Configurable

### DIFF
--- a/lib/omniauth/rails_csrf_protection/token_verifier.rb
+++ b/lib/omniauth/rails_csrf_protection/token_verifier.rb
@@ -1,4 +1,5 @@
 require "active_support/configurable"
+require "active_support/core_ext/class/attribute"
 require "action_controller"
 
 module OmniAuth
@@ -20,10 +21,9 @@ module OmniAuth
       # configurable options. As we want to make sure that our configuration is
       # the same as what being set in `ActionController::Base`, we should make
       # all out configuration methods to delegate to `ActionController::Base`.
-      config.each_key do |configuration_name|
-        undef_method configuration_name
-        define_method configuration_name do
-          ActionController::Base.config[configuration_name]
+      class << self
+        def config
+          ActionController::Base.config
         end
       end
 


### PR DESCRIPTION
An alternative for #24 that's a bit simpler.