### PR TITLE
Update invalid authenticity token exceptions

### DIFF
--- a/lib/omniauth/rails_csrf_protection/token_verifier.rb
+++ b/lib/omniauth/rails_csrf_protection/token_verifier.rb
@@ -50,6 +50,20 @@ module OmniAuth
           end
         end
       end
+      # Rails 8.2 deprecated `ActionController::InvalidAuthenticityToken` in
+      # favour of `ActionController::InvalidCrossOriginRequest` (removal in
+      # Rails 9.0), making the old name a deprecated alias of the new one. On
+      # 8.2+ both constants resolve to the same class, so raising the new one
+      # silences the deprecation warning while still being caught by apps that
+      # `rescue_from ActionController::InvalidAuthenticityToken`. On older Rails
+      # they are distinct sibling classes, so we keep raising the original to
+      # avoid silently bypassing those rescue handlers.
+      INVALID_REQUEST_ERROR =
+        if ActionPack.version >= Gem::Version.new("8.2.a")
+          ActionController::InvalidCrossOriginRequest
+        else
+          ActionController::InvalidAuthenticityToken
+        end
 
       def call(env)
         dup._call(env)
@@ -59,7 +73,7 @@ module OmniAuth
         @request = ActionDispatch::Request.new(env.dup)
 
         unless verified_request?
-          raise ActionController::InvalidAuthenticityToken
+          raise INVALID_REQUEST_ERROR
         end
       end
 
@@ -67,6 +81,13 @@ module OmniAuth
 
         attr_reader :request
         delegate :params, :session, to: :request
+        # Rails 8.2's CSRF instrumentation (instrument_csrf_event, added in
+        # rails/rails#56355) reads `action_name` for its notification payload.
+        # That method normally comes from AbstractController; since we include
+        # RequestForgeryProtection standalone, we stub it.
+        def action_name
+          nil
+        end
     end
   end
 end

--- a/test/application_test.rb
+++ b/test/application_test.rb
@@ -13,14 +13,14 @@ class ApplicationTest < Minitest::Test
     post "/auth/developer"
     follow_redirect!
 
-    assert_equal "ActionController::InvalidAuthenticityToken", last_response.body
+    assert_equal expected_csrf_error_name, last_response.body
   end
 
   def test_request_phrase_with_bad_token_via_post
     post "/auth/developer", authenticity_token: "BAD_TOKEN"
     follow_redirect!
 
-    assert_equal "ActionController::InvalidAuthenticityToken", last_response.body
+    assert_equal expected_csrf_error_name, last_response.body
   end
 
   def test_request_phrase_with_correct_token_via_post

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -27,7 +27,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     visit sign_in_path
     click_on "Sign in"
 
-    refute page.has_content?("ActionController::InvalidAuthenticityToken")
+    refute page.has_content?(expected_csrf_error_name)
 
     fill_in "Name", with: "Kagari Mimi"
     fill_in "Email", with: "mimi@example.com"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,16 @@ def silence_warnings
 ensure
   $VERBOSE = old_verbose
 end
+# Rails 8.2 deprecated ActionController::InvalidAuthenticityToken in favour of
+# ActionController::InvalidCrossOriginRequest, so the CSRF rejection surfaces
+# under a different class name depending on the Rails version under test.
+def expected_csrf_error_name
+  if Rails.gem_version >= Gem::Version.new("8.2.a")
+    "ActionController::InvalidCrossOriginRequest"
+  else
+    "ActionController::InvalidAuthenticityToken"
+  end
+end
 
 silence_warnings do
   require "bundler/inline"


### PR DESCRIPTION
[rails/rails](https://github.com/rails/rails/commit/46eecbfd1a0e339e356b9934c9382f7a803a5a17) — Deprecate InvalidAuthenticityToken in favour of InvalidCrossOriginRequest
Updating the gem to use the new preferred exception. Fixes a deprecation currently.

[rails/rails](https://github.com/rails/rails/pull/56355) added Active Support notifications for CSRF events, whose payload reads action_name during verified_request?. That method comes from AbstractController, which we don't have, so stub it to keep verification working on 8.2.

This PR ensures compatibility with Rails edge (and Rails 8.2 when released).